### PR TITLE
Fix: Added countryCallingCode to 44 countries

### DIFF
--- a/src/constants/countries.js
+++ b/src/constants/countries.js
@@ -275,7 +275,7 @@ export default [
       svg: 'https://flagcdn.com/va.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+379'
   },
   {
     name: 'Seychelles',
@@ -474,7 +474,7 @@ export default [
       svg: 'https://flagcdn.com/ru.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+7'
   },
   {
     name: 'Western Sahara',
@@ -573,7 +573,7 @@ export default [
       svg: 'https://flagcdn.com/tt.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+1 868'
   },
   {
     name: 'Central African Republic',
@@ -612,7 +612,7 @@ export default [
       svg: 'https://flagcdn.com/mk.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+389'
   },
   {
     name: 'El Salvador',
@@ -652,7 +652,7 @@ export default [
       svg: 'https://flagcdn.com/tc.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+1 649'
   },
   {
     name: 'Kosovo',
@@ -730,7 +730,7 @@ export default [
       svg: 'https://flagcdn.com/ir.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+98'
   },
   {
     name: 'French Southern and Antarctic Lands',
@@ -749,7 +749,7 @@ export default [
       svg: 'https://flagcdn.com/tf.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+33'
   },
   {
     name: 'Bouvet Island',
@@ -787,7 +787,7 @@ export default [
       svg: 'https://flagcdn.com/vg.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+1 284'
   },
   {
     name: 'United Arab Emirates',
@@ -858,7 +858,7 @@ export default [
       svg: 'https://flagcdn.com/cz.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+420'
   },
   {
     name: 'Hungary',
@@ -1291,7 +1291,7 @@ export default [
       svg: 'https://flagcdn.com/ps.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+970'
   },
   {
     name: 'Finland',
@@ -1330,7 +1330,7 @@ export default [
       svg: 'https://flagcdn.com/st.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+239'
   },
   {
     name: 'Honduras',
@@ -1525,7 +1525,7 @@ export default [
       svg: 'https://flagcdn.com/tl.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+670'
   },
   {
     name: 'Armenia',
@@ -1584,7 +1584,7 @@ export default [
       svg: 'https://flagcdn.com/gs.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+500'
   },
   {
     name: 'Saint Martin',
@@ -1765,7 +1765,7 @@ export default [
       svg: 'https://flagcdn.com/bo.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+591'
   },
   {
     name: 'United Kingdom',
@@ -1887,7 +1887,7 @@ export default [
       svg: 'https://flagcdn.com/cw.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+599'
   },
   {
     name: 'DR Congo',
@@ -1906,7 +1906,7 @@ export default [
       svg: 'https://flagcdn.com/cd.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+243'
   },
   {
     name: 'Cuba',
@@ -1988,7 +1988,7 @@ export default [
       svg: 'https://flagcdn.com/ba.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+387'
   },
   {
     name: 'Singapore',
@@ -2070,7 +2070,7 @@ export default [
       svg: 'https://flagcdn.com/sz.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+268'
   },
   {
     name: 'Belgium',
@@ -2129,7 +2129,7 @@ export default [
       svg: 'https://flagcdn.com/vc.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+1 784'
   },
   {
     name: 'Nicaragua',
@@ -2211,7 +2211,7 @@ export default [
       svg: 'https://flagcdn.com/ci.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+225'
   },
   {
     name: 'Slovenia',
@@ -2489,7 +2489,7 @@ export default [
       svg: 'https://flagcdn.com/cg.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+242'
   },
   {
     name: 'Grenada',
@@ -2605,7 +2605,7 @@ export default [
       svg: 'https://flagcdn.com/mo.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+853'
   },
   {
     name: 'Marshall Islands',
@@ -2743,7 +2743,7 @@ export default [
       svg: 'https://flagcdn.com/vn.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+84'
   },
   {
     name: 'Brazil',
@@ -2940,7 +2940,7 @@ export default [
       svg: 'https://flagcdn.com/ve.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+58'
   },
   {
     name: 'Gibraltar',
@@ -3016,7 +3016,7 @@ export default [
       svg: 'https://flagcdn.com/ag.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+1 268'
   },
   {
     name: 'Liberia',
@@ -3112,7 +3112,7 @@ export default [
       svg: 'https://flagcdn.com/tz.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+255'
   },
   {
     name: 'Australia',
@@ -3172,7 +3172,7 @@ export default [
       svg: 'https://flagcdn.com/pm.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+508'
   },
   {
     name: 'Mongolia',
@@ -3299,7 +3299,7 @@ export default [
       svg: 'https://flagcdn.com/bn.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+673'
   },
   {
     name: 'Nepal',
@@ -3443,7 +3443,7 @@ export default [
       svg: 'https://flagcdn.com/sy.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+963'
   },
   {
     name: 'Kiribati',
@@ -3524,7 +3524,7 @@ export default [
       svg: 'https://flagcdn.com/kn.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+1 869'
   },
   {
     name: 'Uzbekistan',
@@ -3683,7 +3683,7 @@ export default [
       svg: 'https://flagcdn.com/re.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+262'
   },
   {
     name: 'Pitcairn Islands',
@@ -3702,7 +3702,7 @@ export default [
       svg: 'https://flagcdn.com/pn.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+64'
   },
   {
     name: 'Aruba',
@@ -3867,7 +3867,7 @@ export default [
       svg: 'https://flagcdn.com/sh.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+290'
   },
   {
     name: 'Montserrat',
@@ -4025,7 +4025,7 @@ export default [
       svg: 'https://flagcdn.com/sj.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+47'
   },
   {
     name: 'Fiji',
@@ -4067,7 +4067,7 @@ export default [
       svg: 'https://flagcdn.com/kr.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+82'
   },
   {
     name: 'Puerto Rico',
@@ -4107,7 +4107,7 @@ export default [
       svg: 'https://flagcdn.com/wf.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+681'
   },
   {
     name: 'North Korea',
@@ -4127,7 +4127,7 @@ export default [
       svg: 'https://flagcdn.com/kp.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+850'
   },
   {
     name: 'Taiwan',
@@ -4174,7 +4174,7 @@ export default [
       svg: 'https://flagcdn.com/im.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+44 1624'
   },
   {
     name: 'United States Virgin Islands',
@@ -4193,7 +4193,7 @@ export default [
       svg: 'https://flagcdn.com/vi.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+1 340'
   },
   {
     name: 'Lithuania',
@@ -4543,7 +4543,7 @@ export default [
       svg: 'https://flagcdn.com/gw.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+245'
   },
   {
     name: 'Norway',
@@ -4834,7 +4834,7 @@ export default [
       svg: 'https://flagcdn.com/bq.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+599'
   },
   {
     name: 'Micronesia',
@@ -4854,7 +4854,7 @@ export default [
       svg: 'https://flagcdn.com/fm.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+691'
   },
   {
     name: 'Mozambique',
@@ -4967,7 +4967,7 @@ export default [
       svg: 'https://flagcdn.com/cv.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+238'
   },
   {
     name: 'Laos',
@@ -4987,7 +4987,7 @@ export default [
       svg: 'https://flagcdn.com/la.svg'
     },
     emoji: '',
-    countryCallingCode: ''
+    countryCallingCode: '+856'
   },
   {
     name: 'Austria',


### PR DESCRIPTION
### These countries did not have `countryCallingCode`
_Vatican City, Russia, Trinidad and Tobago, North Macedonia, Turks and Caicos Islands, Iran, French Southern and Antarctic Lands, Bouvet Island, British Virgin Islands, Czechia, Heard Island and McDonald Islands, Palestine, São Tomé and Príncipe, Timor-Leste, South Georgia, Bolivia, Curaçao, DR Congo, Bosnia and Herzegovina, Eswatini, Saint Vincent and the Grenadines, Ivory Coast, Republic of the Congo, Macau, Vietnam, Venezuela, Antigua and Barbuda, Tanzania, Saint Pierre and Miquelon, Brunei, Syria, Saint Kitts and Nevis, Réunion, Pitcairn Islands, Saint Helena, Ascension and Tristan da Cunha, Svalbard and Jan Mayen, South Korea, Wallis and Futuna, North Korea, Isle of Man, United States Virgin Islands, Guinea-Bissau, Caribbean Netherlands, Micronesia, Cape Verde, Laos_

This is what I updated in `/src/constants/country.js` :

1.  Vatican City +379
2.  Russia +7
3.  Trinidad and Tobago +1 868
4.  North Macedonia +389
5.  Turks and Caicos Islands +1 649
6.  Iran +98
7.  French Southern and Antarctic Lands +33
8.  Bouvet Island ""
9.  British Virgin Islands +1 284
10. Czechia +420
11. Heard Island and McDonald Islands ""
12. Palestine +970
13. São Tomé and Príncipe +239
14. Timor-Leste +670
15. South Georgia +500
16. Bolivia +591
17. Curaçao +599
18. DR Congo +243
19. Bosnia and Herzegovina +387
20. Eswatini +268
21. Saint Vincent and the Grenadines +1 784
22. Ivory Coast +225
23. Republic of the Congo +242
24. Macau +853
25. Vietnam +84
26. Venezuela +58
27. Antigua and Barbuda +1 268
28. Tanzania +255
29. Saint Pierre and Miquelon +508
30. Brunei +673
31. Syria +963
32. Saint Kitts and Nevis +1 869
33. Réunion +262
34. Pitcairn Islands +64
35. Saint Helena, Ascension and Tristan da Cunha +290
36. Svalbard and Jan Mayen +47
37. South Korea +82
38. Wallis and Futuna +681
39. North Korea +850
40. Isle of Man +44 1624
41. United States Virgin Islands +1 340
42. Guinea-Bissau +245
43. Caribbean Netherlands +599
44. Micronesia +691
45. Cape Verde +238
46. Laos +856

Sources: 
[https://countrycode.org](https://countrycode.org) 

Testing:
[https://auth.uber.com](https://auth.uber.com/v2/?breeze_local_zone=phx6&next_url=https%3A%2F%2Fm.uber.com%2Flogin-redirect%2F%3FpreviousPath%3D%252F&state=c2Dx4Bd73OCwoO1mLl_-5oBaNw3iCUJp6pK9nJIoago%3D)

I did not find reliable resources to get `countryCallingCode` for these two :
_Bouvet Island, Heard Island and McDonald Islands_